### PR TITLE
use _assert_never to catch JobType errors

### DIFF
--- a/arrsync/api.py
+++ b/arrsync/api.py
@@ -24,6 +24,7 @@ from arrsync.common import (
     Tags,
 )
 from arrsync.config import logger
+from arrsync.utils import _assert_never
 
 
 class Api(object):
@@ -108,14 +109,14 @@ class Api(object):
         full_url = routes.content(job_type=self.job_type, url=self.url)
         json = self.get(url=full_url)
 
-        if self.job_type == JobType.Sonarr:
+        if self.job_type is JobType.Sonarr:
             return list(map(SonarrContent.parse_obj, json))
-        if self.job_type == JobType.Radarr:
+        elif self.job_type is JobType.Radarr:
             return list(map(RadarrContent.parse_obj, json))
-        if self.job_type == JobType.Lidarr:
+        elif self.job_type is JobType.Lidarr:
             return list(map(LidarrContent.parse_obj, json))
-
-        raise TypeError(f"{self.job_type} JobType is unhandled")
+        else:
+            _assert_never(self.job_type)
 
     def save(self, content_item: ContentItem) -> Any:
         full_url = routes.content(job_type=self.job_type, url=self.url)

--- a/arrsync/routes.py
+++ b/arrsync/routes.py
@@ -3,69 +3,70 @@
 from urllib import parse
 
 from arrsync.common import JobType
+from arrsync.utils import _assert_never
 
 
 def status(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return parse.urljoin(url, "api/v3/system/status")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return parse.urljoin(url, "api/v3/system/status")
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return parse.urljoin(url, "api/v1/system/status")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)
 
 
 def content(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return parse.urljoin(url, "api/v3/series")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return parse.urljoin(url, "api/v3/movie")
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return parse.urljoin(url, "api/v1/artist")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)
 
 
 def profile(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return parse.urljoin(url, "api/v3/qualityprofile")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return parse.urljoin(url, "api/v3/qualityprofile")
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return parse.urljoin(url, "api/v1/qualityprofile")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)
 
 
 def tag(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return parse.urljoin(url, "api/v3/tag")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return parse.urljoin(url, "api/v3/tag")
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return parse.urljoin(url, "api/v1/tag")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)
 
 
 def language(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return parse.urljoin(url, "api/v3/languageprofile")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return parse.urljoin(url, "api/v3/language")
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         raise Exception(f"{job_type} does not support language")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)
 
 
 def metadata(job_type: JobType, url: str) -> str:
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return parse.urljoin(url, "api/v1/metadataprofile")
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         raise Exception(f"{job_type} does not support metadata")
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         raise Exception(f"{job_type} does not support metadata")
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)

--- a/arrsync/utils.py
+++ b/arrsync/utils.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
-from typing import List, TypeVar, Union
+from typing import List, NoReturn, TypeVar, Union
 
 from arrsync.common import ContentItem, JobType, Language, LidarrContent, Profile, Tag
 
 T = TypeVar("T", Tag, Profile, Language)
+
+
+def _assert_never(x: NoReturn) -> NoReturn:
+    assert False, "Unhandled type: {}".format(type(x).__name__)
 
 
 def find_in_list(input_list: List[T], query: str) -> Union[T, None]:
@@ -45,11 +49,11 @@ def get_debug_title(item: ContentItem) -> str:
 
 
 def get_search_missing_attribute(job_type: JobType) -> str:
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         return "searchForMissingEpisodes"
-    if job_type == JobType.Radarr:
+    if job_type is JobType.Radarr:
         return "searchForMovie"
-    if job_type == JobType.Lidarr:
+    if job_type is JobType.Lidarr:
         return "searchForMissingAlbums"
-
-    raise TypeError(f"{job_type} JobType is unhandled")
+    else:
+        _assert_never(job_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from arrsync.common import (
     SonarrSyncJob,
     SyncJob,
 )
+from arrsync.utils import _assert_never
 
 
 class CreateSyncJob(Protocol):
@@ -43,16 +44,17 @@ def create_sync_job(
             "dest_profile": "1",
         }
 
-        if job_type == JobType.Sonarr:
+        if job_type is JobType.Sonarr:
             return SonarrSyncJob.parse_obj({**base_attrs, **extra_attrs})
 
-        if job_type == JobType.Radarr:
+        elif job_type is JobType.Radarr:
             return RadarrSyncJob.parse_obj({**base_attrs, **extra_attrs})
 
-        if job_type == JobType.Lidarr:
+        elif job_type is JobType.Lidarr:
             return LidarrSyncJob.parse_obj({**base_attrs, **extra_attrs})
 
-        raise ValueError()
+        else:
+            _assert_never(job_type)
 
     return _create_sync_job
 
@@ -83,7 +85,7 @@ def create_content_item(
             "tags": [],
         }
 
-        if job_type == JobType.Radarr:
+        if job_type is JobType.Radarr:
             return RadarrContent.parse_obj(
                 {
                     "tmdb_id": count,
@@ -94,7 +96,7 @@ def create_content_item(
                 }
             )
 
-        elif job_type == JobType.Sonarr:
+        elif job_type is JobType.Sonarr:
             return SonarrContent.parse_obj(
                 {
                     "tvdb_id": count,
@@ -106,7 +108,7 @@ def create_content_item(
                 }
             )
 
-        elif job_type == JobType.Lidarr:
+        elif job_type is JobType.Lidarr:
             return LidarrContent.parse_obj(
                 {
                     "artist_name": f"Item {count}",
@@ -121,7 +123,8 @@ def create_content_item(
                 }
             )
 
-        raise ValueError()
+        else:
+            _assert_never(job_type)
 
     return _create_content_item
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -26,6 +26,7 @@ from arrsync.lib import (
     start_sync_job,
     sync_content,
 )
+from arrsync.utils import _assert_never
 
 
 def item_in_list(items: ContentItems, search_item: ContentItem) -> bool:
@@ -502,12 +503,14 @@ def test_get_content_payloads_search_missing(
     assert payload
     assert payload.add_options
 
-    if job_type == JobType.Sonarr:
+    if job_type is JobType.Sonarr:
         assert payload.add_options["searchForMissingEpisodes"]
-    if job_type == JobType.Radarr:
+    elif job_type is JobType.Radarr:
         assert payload.add_options["searchForMovie"]
-    if job_type == JobType.Lidarr:
+    elif job_type is JobType.Lidarr:
         assert payload.add_options["searchForMissingAlbums"]
+    else:
+        _assert_never(job_type)
 
 
 def test_get_content_payloads_sonarr_languages(


### PR DESCRIPTION
Previously JobType errors were only caught with pytest, however with
_assert_never we can also catch them during typechecking

<!--
Before you open this PR:
- Ensure flake8, isort, mypy and black all pass with out error
- Ensure tests are written for any new code or updated when changing existing code. Any PR that reduces coverage below 100% will be rejected
- Write a clear and concise description of what your PR changes and how to test
-->
